### PR TITLE
UI: Fix DATAVIEW width calculation to remove horizontal scrollbar

### DIFF
--- a/NuvoISP/DialogHex.cpp
+++ b/NuvoISP/DialogHex.cpp
@@ -117,7 +117,7 @@ void CDialogHex::OnSize(UINT nType, int cx, int cy)
         /* Set edit area */
         CRect rcEdit;
         rcEdit.left = rcClient.left + 0;
-        rcEdit.right = rcButton.left - 12;
+        rcEdit.right = rcClient.right - (rcButton.right - rcButton.left) - 12 - 12;		
         rcEdit.top = rcClient.top + 1;
         rcEdit.bottom = rcClient.bottom - 0;
         ScreenToClient(rcEdit);
@@ -136,12 +136,12 @@ void CDialogHex::OnSize(UINT nType, int cx, int cy)
             if (pRadio != NULL && pRadio->GetSafeHwnd()) {
                 CRect rcRadio;
                 pRadio->GetWindowRect(rcRadio);
+                ScreenToClient(&rcRadio);
                 int nHeight = rcRadio.Height();
                 rcRadio.right += rcButton.left - 1 - rcRadio.left;
                 rcRadio.left = rcButton.left - 1;
-                rcRadio.bottom += (rcClient.top + 6 + i * (nHeight + 4) - rcRadio.top);
-                rcRadio.top = rcClient.top + 6 + i * (nHeight + 4);
-                ScreenToClient(&rcRadio);
+                rcRadio.top = 6 + i * (nHeight + 4);
+                rcRadio.bottom = rcRadio.top + nHeight;
                 pRadio->MoveWindow(rcRadio);
             }
         }


### PR DESCRIPTION

Hi, 
Propose to remove horizontal scrollbar in DATAVIEW

Before:
![image](https://user-images.githubusercontent.com/13328211/146636379-ba000437-6800-495a-88fb-70b732f03ae4.png)

After:
![image](https://user-images.githubusercontent.com/13328211/146636397-0ea620b7-cc83-473b-847d-53425a75360c.png)


The cause is mix of "screen" and "client" coordinates in calculation.
Now only one type of coordinates used in same calculation.

Thanks.